### PR TITLE
#27 refactor: unify database envs into a single DB_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
-#DATABASE
-DB_HOST=database # or localhost for dev
-DB_PORT=5432
-DB_USER=postgres
-DB_PASSWORD=123456
-DB_NAME=first_crud
+# DATABASE
+# host: "database" (docker), "localhost" (local)
+DB_URL=postgresql://fastapi:12345678@database:5432/fastapi_db 

--- a/app/configs/database.py
+++ b/app/configs/database.py
@@ -1,10 +1,8 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-from app.configs.env import DB_HOST, DB_NAME, DB_PASSWORD, DB_PORT, DB_USER
+from app.configs.env import DB_URL
 
-
-DB_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 
 engine = create_engine(
     DB_URL,

--- a/app/configs/env.py
+++ b/app/configs/env.py
@@ -6,8 +6,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-DB_HOST = os.getenv("DB_HOST")
-DB_PORT = os.getenv("DB_PORT")
-DB_USER = os.getenv("DB_USER")
-DB_PASSWORD = os.getenv("DB_PASSWORD")
-DB_NAME = os.getenv("DB_NAME")
+DB_URL = os.getenv("DB_URL")
+
+if not DB_URL:
+    raise RuntimeError("DB_URL não definida")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 name: first-cicd
 
 services:
-  app:
+  api:
     build:
       context: .
       dockerfile: Dockerfile
@@ -14,21 +14,22 @@ services:
         condition: service_healthy
 
   database:
-    image: postgres:16-alpine
-    env_file:
-      - .env
+    image: postgres:18-alpine
     environment:
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: fastapi
+      POSTGRES_PASSWORD: 12345678
+      POSTGRES_DB: fastapi_db
     ports:
-      - "${DB_PORT}:5432"
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test:
-        ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+        ["CMD-SHELL", "pg_isready -U fastapi -d fastapi_db"]
       interval: 5s
       timeout: 5s
       retries: 5
       start_period: 5s
 
-    
+volumes:
+  postgres_data:


### PR DESCRIPTION
- Replace DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_NAME with a single DB_URL
- Consume DB_URL directly in env.py and database.py (no more f-string)
- Bump postgres image to 18-alpine
- Add named volume postgres_data mounted at /var/lib/postgresql (PG18 PGDATA)
- Align credentials across .env, compose and healthcheck (fastapi/fastapi_db)

closes #27 
