### PR TITLE
#35 docs: add detailed examples and descriptions to API docs

### DIFF
--- a/app/controllers/health_controller.py
+++ b/app/controllers/health_controller.py
@@ -14,13 +14,13 @@ class HealthController:
             # Testa a conexão executando uma query simples
             self.db.execute(text("SELECT 1"))
 
-            response = HealthResponse(status="Ok", message="Postgres databse está on")
+            response = HealthResponse(status="Ok", message="Postgres database está on")
             return JSONResponse(
                 content=response.model_dump()
             )
 
         except Exception as e:
-            response = HealthResponse(status="Failure", message="Postgres databse está off")
+            response = HealthResponse(status="Failure", message="Postgres database está off")
             return JSONResponse(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 content=response.model_dump()

--- a/app/routes/health_router.py
+++ b/app/routes/health_router.py
@@ -6,15 +6,44 @@ from app.controllers.health_controller import HealthController
 from app.schemas.health_schema import HealthResponse
 
 
-router = APIRouter(prefix="/health", tags=["health"])
+router = APIRouter(prefix="/health", tags=["Health"])
 
 
 @router.get(
     "",
+    response_model=HealthResponse,
+    summary="Verificar saúde da aplicação",
+    description=(
+        "Verifica a saúde da aplicação testando a conexão com o banco de "
+        "dados (Postgres). Responde 200 quando o banco está acessível e 503 "
+        "quando a conexão falha."
+    ),
     responses={
-        200: {"model": HealthResponse},
-        503: {"model": HealthResponse}
-    }
+        200: {
+            "model": HealthResponse,
+            "description": "Aplicação e banco de dados operacionais",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "status": "Ok",
+                        "message": "Postgres database está on",
+                    }
+                }
+            },
+        },
+        503: {
+            "model": HealthResponse,
+            "description": "Banco de dados indisponível",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "status": "Failure",
+                        "message": "Postgres database está off",
+                    }
+                }
+            },
+        },
+    },
 )
 async def healthchecker(db: Session = Depends(get_db)):
     controller = HealthController(db)

--- a/app/routes/post_router.py
+++ b/app/routes/post_router.py
@@ -1,6 +1,7 @@
+from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Path
 from sqlalchemy.orm import Session
 
 from app.configs.database import get_db
@@ -8,20 +9,57 @@ from app.controllers.post_controller import PostController
 from app.schemas.post_schema import PostCreateDto, PostResponseDto, PostUpdateDto
 from app.schemas.responses import IdResponse, ErrorResponse, PaginationResponse
 
-router = APIRouter(prefix="/posts", tags=["posts"])
+router = APIRouter(prefix="/posts", tags=["Posts"])
+
+PostIdPath = Annotated[
+    UUID,
+    Path(
+        description="ID do Post (UUID)",
+        openapi_examples={
+            "exemplo": {
+                "summary": "UUID de exemplo",
+                "value": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            },
+        },
+    ),
+]
+
+PageQuery = Annotated[
+    int,
+    Query(ge=1, description="Número da página a ser retornada (começa em 1)"),
+]
+
+LimitQuery = Annotated[
+    int,
+    Query(ge=1, description="Quantidade de Posts por página"),
+]
 
 
-@router.get("", response_model=PaginationResponse[PostResponseDto])
+@router.get(
+    "",
+    response_model=PaginationResponse[PostResponseDto],
+    summary="Listar Posts",
+    description=(
+        "Retorna uma lista paginada de todos os Posts cadastrados. "
+        "Use os parâmetros `page` e `limit` para navegar entre as páginas."
+    ),
+)
 async def find_all(
-    page: int = Query(default=1, ge=1),
-    limit: int = Query(default=10, ge=1),
+    page: PageQuery = 1,
+    limit: LimitQuery = 10,
     db: Session = Depends(get_db),
 ):
     controller = PostController(db)
     return controller.find_all(page, limit)
 
 
-@router.post("", response_model=IdResponse, status_code=201)
+@router.post(
+    "",
+    response_model=IdResponse,
+    status_code=201,
+    summary="Criar Post",
+    description="Cria um novo Post e retorna o ID (UUID) gerado para o registro.",
+)
 async def create(data: PostCreateDto, db: Session = Depends(get_db)):
     controller = PostController(db)
     return controller.create(data)
@@ -30,28 +68,74 @@ async def create(data: PostCreateDto, db: Session = Depends(get_db)):
 @router.get(
     "/{post_id}",
     response_model=PostResponseDto,
-    responses={404: {"model": ErrorResponse}},
+    responses={
+        404: {
+            "model": ErrorResponse,
+            "content": {
+                "application/json": {"example": {"message": "Post não encontrado"}}
+            },
+        }
+    },
+    summary="Buscar Post por ID",
+    description=(
+        "Retorna os dados de um Post específico a partir do seu ID (UUID). "
+        "Responde 404 caso o Post não seja encontrado."
+    ),
 )
-async def find_by_id(post_id: UUID, db: Session = Depends(get_db)):
+async def find_by_id(post_id: PostIdPath, db: Session = Depends(get_db)):
     controller = PostController(db)
     return controller.find_by_id(post_id)
 
 
 @router.get(
-    "/username/{posts_username}", response_model=PaginationResponse[PostResponseDto]
+    "/username/{posts_username}",
+    response_model=PaginationResponse[PostResponseDto],
+    summary="Listar Posts por username",
+    description=(
+        "Retorna uma lista paginada de Posts cujo username contém o termo "
+        "informado (busca parcial, sem diferenciar posição do texto)."
+    ),
 )
 async def find_all_by_username(
-    posts_username: str,
-    page: int = Query(default=1, ge=1),
-    limit: int = Query(default=10, ge=1),
+    posts_username: Annotated[
+        str,
+        Path(
+            description="Username (ou parte dele) para filtrar os Posts",
+            openapi_examples={
+                "exemplo": {
+                    "summary": "Username de exemplo",
+                    "value": "juninhogameplays",
+                },
+            },
+        ),
+    ],
+    page: PageQuery = 1,
+    limit: LimitQuery = 10,
     db: Session = Depends(get_db),
 ):
     controller = PostController(db)
     return controller.find_all_by_username(posts_username, page, limit)
 
 
-@router.patch("/{post_id}")
-async def update(post_id: UUID, data: PostUpdateDto, db: Session = Depends(get_db)):
+@router.patch(
+    "/{post_id}",
+    responses={
+        404: {
+            "model": ErrorResponse,
+            "content": {
+                "application/json": {"example": {"message": "Post não encontrado"}}
+            },
+        }
+    },
+    summary="Atualizar Post",
+    description=(
+        "Atualiza o conteúdo (body) de um Post existente. "
+        "Responde 404 caso o Post não seja encontrado."
+    ),
+)
+async def update(
+    post_id: PostIdPath, data: PostUpdateDto, db: Session = Depends(get_db)
+):
     controller = PostController(db)
     return controller.update(post_id, data)
 
@@ -59,9 +143,27 @@ async def update(post_id: UUID, data: PostUpdateDto, db: Session = Depends(get_d
 @router.patch(
     "/archive/{post_id}",
     status_code=204,
-    responses={404: {"model": ErrorResponse}, 409: {"model": ErrorResponse}},
+    responses={
+        404: {
+            "model": ErrorResponse,
+            "content": {
+                "application/json": {"example": {"message": "Post não encontrado"}}
+            },
+        },
+        409: {
+            "model": ErrorResponse,
+            "content": {
+                "application/json": {"example": {"message": "Post já está arquivado"}}
+            },
+        },
+    },
+    summary="Arquivar Post",
+    description=(
+        "Marca um Post como arquivado. Responde 404 caso o Post não seja "
+        "encontrado e 409 caso ele já esteja arquivado."
+    ),
 )
-async def archive(post_id: UUID, db: Session = Depends(get_db)):
+async def archive(post_id: PostIdPath, db: Session = Depends(get_db)):
     controller = PostController(db)
     return controller.archive(post_id)
 
@@ -69,14 +171,50 @@ async def archive(post_id: UUID, db: Session = Depends(get_db)):
 @router.patch(
     "/unarchive/{post_id}",
     status_code=204,
-    responses={404: {"model": ErrorResponse}, 409: {"model": ErrorResponse}},
+    responses={
+        404: {
+            "model": ErrorResponse,
+            "content": {
+                "application/json": {"example": {"message": "Post não encontrado"}}
+            },
+        },
+        409: {
+            "model": ErrorResponse,
+            "content": {
+                "application/json": {
+                    "example": {"message": "Post já está desarquivado"}
+                }
+            },
+        },
+    },
+    summary="Desarquivar Post",
+    description=(
+        "Remove a marcação de arquivado de um Post. Responde 404 caso o Post "
+        "não seja encontrado e 409 caso ele já esteja desarquivado."
+    ),
 )
-async def unarchive(post_id: UUID, db: Session = Depends(get_db)):
+async def unarchive(post_id: PostIdPath, db: Session = Depends(get_db)):
     controller = PostController(db)
     return controller.unarchive(post_id)
 
 
-@router.delete("/{post_id}", status_code=204, responses={404: {"model": ErrorResponse}})
-async def delete(post_id: UUID, db: Session = Depends(get_db)):
+@router.delete(
+    "/{post_id}",
+    status_code=204,
+    responses={
+        404: {
+            "model": ErrorResponse,
+            "content": {
+                "application/json": {"example": {"message": "Post não encontrado"}}
+            },
+        }
+    },
+    summary="Excluir Post",
+    description=(
+        "Remove permanentemente um Post a partir do seu ID (UUID). "
+        "Responde 404 caso o Post não seja encontrado."
+    ),
+)
+async def delete(post_id: PostIdPath, db: Session = Depends(get_db)):
     controller = PostController(db)
     return controller.delete(post_id)

--- a/app/schemas/health_schema.py
+++ b/app/schemas/health_schema.py
@@ -1,5 +1,12 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
 
 class HealthResponse(BaseModel):
-    status: str
-    message: str
+    status: str = Field(
+        description="Estado da verificação de saúde da aplicação",
+        examples=["Ok"],
+    )
+    message: str = Field(
+        description="Detalhe sobre o resultado da verificação",
+        examples=["Postgres database está on"],
+    )

--- a/app/schemas/post_schema.py
+++ b/app/schemas/post_schema.py
@@ -8,6 +8,7 @@ class PostBase(BaseModel):
         min_length=1,
         max_length=255,
         description="O body deve ter entre 1 e 255 caracteres",
+        examples=["Hey, Marceline!"],
     )
 
 
@@ -16,6 +17,7 @@ class PostCreateDto(PostBase):
         min_length=3,
         max_length=50,
         description="O username deve ter entre 3 e 50 caracteres",
+        examples=["juninhogameplays"],
     )
 
 
@@ -24,8 +26,23 @@ class PostUpdateDto(PostBase):
 
 
 class PostResponseDto(PostBase):
-    id: UUID
-    username: str
-    archived: bool
-    created_at: datetime
-    updated_at: datetime
+    id: UUID = Field(
+        description="Identificador único do Post (UUID)",
+        examples=["3fa85f64-5717-4562-b3fc-2c963f66afa6"],
+    )
+    username: str = Field(
+        description="Autor do Post",
+        examples=["juninhogameplays"],
+    )
+    archived: bool = Field(
+        description="Indica se o Post está arquivado",
+        examples=[False],
+    )
+    created_at: datetime = Field(
+        description="Data de criação do Post",
+        examples=["2026-07-18T12:00:00"],
+    )
+    updated_at: datetime = Field(
+        description="Data da última atualização do Post",
+        examples=["2026-07-18T12:00:00"],
+    )

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -1,14 +1,20 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Generic, TypeVar
 from uuid import UUID
 
 
 class IdResponse(BaseModel):
-    id: UUID
+    id: UUID = Field(
+        description="Identificador único do recurso criado (UUID)",
+        examples=["3fa85f64-5717-4562-b3fc-2c963f66afa6"],
+    )
 
 
 class ErrorResponse(BaseModel):
-    message: str
+    message: str = Field(
+        description="Mensagem de erro",
+        examples=[""],
+    )
 
 
 T = TypeVar("T")
@@ -16,7 +22,19 @@ T = TypeVar("T")
 
 class PaginationResponse(BaseModel, Generic[T]):
     data: list[T]
-    items_per_page: int
-    total_items: int
-    current_page: int
-    total_pages: int
+    items_per_page: int = Field(
+        description="Quantidade de itens por página",
+        examples=[10],
+    )
+    total_items: int = Field(
+        description="Total de itens encontrados",
+        examples=[1],
+    )
+    current_page: int = Field(
+        description="Página atual",
+        examples=[1],
+    )
+    total_pages: int = Field(
+        description="Total de páginas disponíveis",
+        examples=[1],
+    )


### PR DESCRIPTION
- Add request/response/path-param examples to Post schemas and routes
- Add pt-BR summary and description to all Post and Health routes
- Document per-route ErrorResponse messages (404/409) via response content
- Add descriptions to pagination query params (page, limit)
- Capitalize the "Post"/"Posts" entity across docs and tags
- Document the Health check route (summary, description, 200/503 examples)
- Fix typo "databse" -> "database" in Health messages

closes #35 